### PR TITLE
Don't throw exception when local.properties not found

### DIFF
--- a/sdk_manager.gradle
+++ b/sdk_manager.gradle
@@ -36,7 +36,7 @@ ext.guessNdkDir = {
 
 ext.readLocalPropertiesValue = { key ->
     if (!project.file("local.properties").exists()) {
-        return null
+        return ""
     }
 
     Properties properties = new Properties()
@@ -52,7 +52,7 @@ ext.installRequiredSdk = { appExtension, sdkDir=readLocalPropertiesValue("sdk.di
         throw new IllegalArgumentException("compileSdkVersion and buildToolsRevision must not be null")
     }
 
-    if (sdkDir == null) {
+    if (!(sdkDir)) {
         throw new GradleException("sdkDir does not exist")
     }
 


### PR DESCRIPTION
CIサーバーで `installRequiredSdk(android, guessSdkDir())` がうまくいってなかったので調べていたら、`guessSdkDir` を呼んだときにまず `readLocalPropertiesValue` を呼んで `local.properties` を見にいきますが、`local.properties` が存在していなかったら例外を投げて他のパスを見にいかなくなってしまうので、例外を投げずにnullを返すようにしました。
