### PR TITLE
Find the tools/android file in SDK directory for Windows

### DIFF
--- a/sdk_manager.gradle
+++ b/sdk_manager.gradle
@@ -57,8 +57,9 @@ ext.installRequiredSdk = { appExtension, sdkDir=readLocalPropertiesValue("sdk.di
     }
 
     def workers = []
+    def sdkToolsAndroidExecFilePath = findSdkToolsAndroidExecFile(sdkDir)
     buildComponents(sdkDir, compileSdkVersion, buildToolsRevision).each { component ->
-        workers.add(Thread.start{ runInstall(sdkDir, component) })
+        workers.add(Thread.start{ runInstall(sdkToolsAndroidExecFilePath, component) })
     }
     workers*.join()
 }
@@ -80,12 +81,10 @@ private def buildComponents(sdkDir, compileSdkVersion, buildToolsRevision) {
     return components
 }
 
-private def runInstall(sdkDir, component) {
-    def android = "$sdkDir/tools/android"
-
+private def runInstall(String sdkToolsAndroidExecFilePath, component) {
     def leftProc = "echo y".execute()
     def rightProc = [
-            "${android}",
+            sdkToolsAndroidExecFilePath,
             "update",
             "sdk",
             "--no-ui",
@@ -100,4 +99,16 @@ private def pipe(leftProc, rightProc) {
     leftProc | rightProc
     rightProc.in.eachLine { line -> println line }
     rightProc.waitFor()
+}
+
+private String findSdkToolsAndroidExecFile(String sdkDir) {
+    // "android" for Linux and OS X, "android.bat" for Windows
+    def fileNameCandidates = ["android", "android.bat"]
+    for (def fileName : fileNameCandidates) {
+        def candidateFilePath = "${sdkDir}/tools/${fileName}"
+        if (file(candidateFilePath).exists()) {
+            return candidateFilePath
+        }
+    }
+    throw new RuntimeException("Executable file `android` not found")
 }


### PR DESCRIPTION
Windows で動作しませんでしたので、変更を行いました。 問題なさそうであれば取り込んで頂けると幸いです。
## 前提

Linux や OS X の Android SDK ディレクトリ内の tools/android ファイルに相当するものが、Windows では tools/android.bat というファイル名になっています。
## 問題

現在の実装では、tools/android という名前のファイルを使用しようとしていますので、Windows で実行すると次のようなエラーが発生します。 (ちょっと文字化けしていますが、実行しようとしたファイルがないというエラーです。)

```
Exception in thread "Thread-4" org.codehaus.groovy.runtime.InvokerInvocationException: java.io.IOException: Cannot run program "C:/xxxx/Android/_dev_tools/sdk_tools_for_test/android-sdk_r22.6-windows/android-sdk-windows/tools/android": CreateProcess error=2, ﾂ指ﾂ定さﾂれたﾂフﾂァﾂ・
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:97)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:877)
        at groovy.lang.Closure.call(Closure.java:412)
        at groovy.lang.Closure.call(Closure.java:406)
        at groovy.lang.Closure.run(Closure.java:490)
        at java.lang.Thread.run(Thread.java:744)
```
## 解決案と今回採った方法

思い浮かんだ解決案としては次の 2 つがあります。
- tools/android ファイルの候補として 「tools/android」 と 「tools/android.bat」 を持っておき、ファイルが存在するかどうかチェックするようにする。
- Windows の場合は `cmd /c D:/xxx/.../tools/android ...` という感じで Cmd.exe コマンドインタープリタ経由で実行するようにする。
  - Cmd.exe コマンドインタープリタ経由で実行すると、ファイル名末尾の 「.bat」 を自動で保管してくれるので。
  - 参考: [コマンドシェルの概要](http://technet.microsoft.com/ja-jp/library/cc737438%28WS.10%29.aspx)

いまいち OS の判別をするのは気がのらないため、前者の方法を採用しました。
## 変更内容
- `findSdkToolsAndroidExecFile` メソッドを新たに作成し、「tools/android」 ファイルと 「tools/android.bat」 ファイルから存在するものを返すようにしました。
- `runInstall` メソッドの第 1 引数として SDK ディレクトリパスを受け取るのではなく、tools/android ファイルのパスを受け取るように変更しました。
  - あわせて `runInstall` メソッドの呼び出し側を変更しました。
