### PR TITLE
applyするURLの更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This plugin manages Android SDK and build tools for gradle.
 ## Installation
 
 ```groovy
-apply from: 'https://raw2.github.com/cookpad/gradle-android-sdk-manager/master/sdk_manager.gradle'
+apply from: 'https://raw.githubusercontent.com/cookpad/gradle-android-sdk-manager/master/sdk_manager.gradle'
 ```
 
 ## Usage


### PR DESCRIPTION
githubのraw fileのURLが変更になったようなので、
README.mdでの記述も変更した方がよさそうです。

参考にしたURL:
https://developer.github.com/changes/2014-04-25-user-content-security/
